### PR TITLE
Add serve command

### DIFF
--- a/Source/Commands/Help.php
+++ b/Source/Commands/Help.php
@@ -31,6 +31,7 @@ work on an existing project
 
 global access
     run                 Run a project on the fly
+    serve               Serve a project on the fly
     version             Print current version number
 EOD;
 

--- a/Source/Commands/Man.php
+++ b/Source/Commands/Man.php
@@ -52,7 +52,7 @@ work with packages
 work on an existing project
     build [{dev}|production]
                     Builds project and adds built files to environment's build directory under the `build` directory. By
-                    default environment will be `development`. You can pass the environment argument as `production` 
+                    default, environment will be `development`. You can pass the environment argument as `production` 
                     when you want to build the production environment.
     watch
                     By running this command, phpkg builds your file while you are doing your development. This command
@@ -61,9 +61,14 @@ work on an existing project
                     If you need to delete any built files, running this command will give you a fresh `builds` directory.
 
 global access
-    run <package>
+    run <package> <entrypoint>
                     Downloads, builds and runs the given package on the fly. You need to pass a valid git URL (SSH or HTTPS)
-                    to this command.
+                    to this command. If the package has more than one entrypoint, you can specify the entrypoint as the
+                    second argument.
+    serve <package> <entrypoint>
+                    Downloads, builds and serves the given package on the fly. You need to pass a valid git URL (SSH or HTTPS)
+                    to this command. If the package has more than one entrypoint, you can specify the entrypoint as the
+                    second argument.
     version
                     Prints current version number.
 EOD;

--- a/Source/Commands/Serve.php
+++ b/Source/Commands/Serve.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Phpkg\Commands\Serve;
+
+use Phpkg\Classes\Build\Build;
+use Phpkg\Classes\Config\Config;
+use Phpkg\Classes\Config\LinkPair;
+use Phpkg\Classes\Environment\Environment;
+use Phpkg\Classes\Meta\Dependency;
+use Phpkg\Classes\Meta\Meta;
+use Phpkg\Classes\Package\Package;
+use Phpkg\Classes\Project\Project;
+use Phpkg\Exception\PreRequirementsFailedException;
+use Phpkg\Git\Repository;
+use Phpkg\PackageManager;
+use PhpRepos\FileManager\Directory;
+use PhpRepos\FileManager\File;
+use PhpRepos\FileManager\Filename;
+use PhpRepos\FileManager\JsonFile;
+use PhpRepos\FileManager\Path;
+use function Phpkg\Commands\Build\add_autoloads;
+use function Phpkg\Commands\Build\add_executables;
+use function Phpkg\Commands\Build\compile_packages;
+use function Phpkg\Commands\Build\compile_project_files;
+use function PhpRepos\Cli\IO\Read\argument;
+use function PhpRepos\Cli\IO\Write\line;
+
+function run(Environment $environment): void
+{
+    $package_url = argument(2);
+
+    line("Serving $package_url on http://localhost:8000");
+
+    set_credentials($environment);
+
+    $project = init_project($package_url);
+    install_packages($project);
+    $build = prepare_build($project);
+    build($project, $build);
+
+    $entry_point = argument(3) ? argument(3) : $project->config->entry_points->first();
+
+    $entry_point_path = $build->root()->append($entry_point);
+
+    if (! File\exists($entry_point_path)) {
+        throw new PreRequirementsFailedException("Entry point $entry_point is not defined in the package.");
+    }
+
+    $command = 'php -S localhost:8000 -t ' . $entry_point_path->parent();
+
+    $process = proc_open($command, [STDIN, STDOUT, STDOUT], $pipes);
+
+    $terminate_server = function ($signal) use ($process) {
+        $pid = proc_get_status($process)['pid'];
+        posix_kill($pid, $signal);
+        exit();
+    };
+
+    pcntl_signal(SIGTERM, $terminate_server);
+    pcntl_signal(SIGINT, $terminate_server);
+
+    while (true) {
+        pcntl_signal_dispatch();
+        usleep(100);
+    }
+}
+
+function init_project(string $package_url): Project
+{
+    $repository = Repository::from_url($package_url);
+    $repository->version(PackageManager\get_latest_version($repository));
+    $repository->hash(PackageManager\detect_hash($repository));
+
+    $root = Path::from_string(sys_get_temp_dir())->append('phpkg/runner/' . $repository->owner . '/' . $repository->repo . '/' . $repository->version);
+
+    unless(Directory\exists($root), fn () => PackageManager\download($repository, $root));
+
+    $project = new Project($root);
+
+    $project->config(Config::from_array(JsonFile\to_array($project->config_file)));
+    $project->meta = Meta::from_array(JsonFile\to_array($project->meta_file));
+
+    Directory\exists_or_create($project->packages_directory);
+
+    return $project;
+}
+
+function install_packages(Project $project)
+{
+    $project->meta->dependencies->each(function (Dependency $dependency) use ($project) {
+        $package = new Package($project->package_directory($dependency->repository()), $dependency->repository());
+        unless(Directory\exists($package->root), fn () => PackageManager\download($package->repository, $package->root));
+        $package->config = File\exists($package->config_file) ? Config::from_array(JsonFile\to_array($package->config_file)) : Config::init();
+        $project->packages->push($package);
+    });
+}
+
+function prepare_build(Project $project): Build
+{
+    $build = new Build($project, 'production');
+    Directory\renew_recursive($build->root());
+    Directory\exists_or_create($build->packages_directory());
+    $build->load_namespace_map();
+
+    return $build;
+}
+
+function build(Project $project, Build $build): void
+{
+    $project->packages->each(function (Package $package) use ($project, $build) {
+        compile_packages($package, $build);
+    });
+
+    compile_project_files($build);
+
+    $project->config->entry_points->each(function (Filename $entry_point) use ($build) {
+        add_autoloads($build, $build->root()->append($entry_point));
+    });
+
+    $project->packages->each(function (Package $package)  use ($project, $build) {
+        $package->config->executables->each(function (LinkPair $executable) use ($build, $package) {
+            add_executables($build, $build->package_root($package)->append($executable->source()), $build->root()->append($executable->symlink()));
+        });
+    });
+}

--- a/Source/Commands/Version.php
+++ b/Source/Commands/Version.php
@@ -6,5 +6,5 @@ use PhpRepos\Cli\IO\Write;
 
 function run(): void
 {
-    Write\success('phpkg version 1.0.0');
+    Write\success('phpkg version 1.1.0');
 }

--- a/Tests/System/HelpCommandTest.php
+++ b/Tests/System/HelpCommandTest.php
@@ -31,6 +31,7 @@ work on an existing project
 
 global access
     run                 Run a project on the fly
+    serve               Serve a project on the fly
     version             Print current version number
 EOD;
 

--- a/Tests/System/ManCommandTest.php
+++ b/Tests/System/ManCommandTest.php
@@ -52,7 +52,7 @@ work with packages
 work on an existing project
     build [{dev}|production]
                     Builds project and adds built files to environment's build directory under the `build` directory. By
-                    default environment will be `development`. You can pass the environment argument as `production` 
+                    default, environment will be `development`. You can pass the environment argument as `production` 
                     when you want to build the production environment.
     watch
                     By running this command, phpkg builds your file while you are doing your development. This command
@@ -61,9 +61,14 @@ work on an existing project
                     If you need to delete any built files, running this command will give you a fresh `builds` directory.
 
 global access
-    run <package>
+    run <package> <entrypoint>
                     Downloads, builds and runs the given package on the fly. You need to pass a valid git URL (SSH or HTTPS)
-                    to this command.
+                    to this command. If the package has more than one entrypoint, you can specify the entrypoint as the
+                    second argument.
+    serve <package> <entrypoint>
+                    Downloads, builds and serves the given package on the fly. You need to pass a valid git URL (SSH or HTTPS)
+                    to this command. If the package has more than one entrypoint, you can specify the entrypoint as the
+                    second argument.
     version
                     Prints current version number.
 EOD;

--- a/Tests/System/ServeCommand/ServeCommandTest.php
+++ b/Tests/System/ServeCommand/ServeCommandTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\System\ServeCommand\ServeCommandTest;
+
+use Exception;
+use PhpRepos\FileManager\Path;
+use function PhpRepos\FileManager\Directory\delete_recursive;
+use function PhpRepos\FileManager\Directory\make_recursive;
+use function PhpRepos\FileManager\File\content;
+use function PhpRepos\FileManager\File\delete;
+use function PhpRepos\FileManager\Resolver\root;
+use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
+use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Runner\test;
+
+test(
+    title: 'it should serve the given application',
+    case: function () {
+        $command = 'php ' . root() . 'phpkg serve https://github.com/php-repos/daily-routine.git';
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($command, $descriptors, $pipes);
+
+        assert_true($process !== false, 'Failed to run the serve command');
+
+        stream_set_blocking($pipes[1], 0);
+        stream_set_blocking($pipes[2], 0);
+        $output = '';
+        $error = '';
+        sleep(1);
+
+        assert_true(str_contains($output .= stream_get_contents($pipes[1]), 'Serving https://github.com/php-repos/daily-routine.git on http://localhost:8000'), 'Serve did not work.');
+        assert_true(empty($error .= stream_get_contents($pipes[2])), 'there is an error while serving: ' . $error);
+
+        $serve_is_running = true;
+        while ($serve_is_running) {
+            usleep(200);
+            $serve_is_running =
+                ! str_contains($output .= stream_get_contents($pipes[1]), 'Development Server (http://localhost:8000) started')
+                && empty($error .= stream_get_contents($pipes[2]));
+        }
+
+        assert_project_is_working();
+        assert_kill_works_for_webserver($process);
+    },
+    after: function () {
+        delete_recursive(Path::from_string(sys_get_temp_dir())->append('phpkg/runner/php-repos/daily-routine'));
+    }
+);
+
+test(
+    title: 'it should show error message when the entry point is not defined for serve',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'phpkg serve https://github.com/php-repos/daily-routine.git not-exists.php');
+
+        $expected = <<<EOD
+\e[39mServing https://github.com/php-repos/daily-routine.git on http://localhost:8000
+\e[91mEntry point not-exists.php is not defined in the package.\e[39m
+
+EOD;
+
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+    },
+    after: function () {
+        delete_recursive(Path::from_string(sys_get_temp_dir())->append('phpkg/runner/php-repos/daily-routine'));
+    }
+);
+
+test(
+    title: 'it should use existed version when it is available for serve',
+    case: function (Path $path) {
+        $output = Path::from_string(sys_get_temp_dir())->append('run-output.txt');
+        $descriptor_spec = [
+            STDIN,
+            ['file', $output->string(), "a"],
+            ['file', $output->string(), "a"]
+        ];
+        $proc = proc_open('php ' . root() . 'phpkg serve https://github.com/php-repos/daily-routine.git', $descriptor_spec, $pipes);
+        proc_close($proc);
+
+        assert_true(str_contains(content($output), "PHP Warning:  file_get_contents({$path->string()}/phpkg.config.json): Failed to open stream"));
+
+        return $output;
+    },
+    before: function () {
+        $path = Path::from_string(sys_get_temp_dir())->append('phpkg/runner/php-repos/daily-routine/v1.0.0');
+        make_recursive($path);
+
+        return $path;
+    },
+    after: function (Path $output) {
+        delete($output);
+        delete_recursive(Path::from_string(sys_get_temp_dir())->append('phpkg/runner/php-repos/daily-routine'));
+    }
+);
+
+function assert_project_is_working(): void
+{
+    $response = get();
+
+    assert_true(empty($response['error']), $response['error']);
+    assert_true(str_contains($response['response'], '<title>Daily Routine</title>'), 'Application\'s response is not correct.' . $response['response']);
+}
+
+function assert_kill_works_for_webserver($process): void
+{
+    // 10 Seconds!
+    $timeout = 10000000;
+    $interval = 2000;
+
+    $port_is_open = function () {
+        $socket = @fsockopen('localhost', 8000, $error_code, $error_message, 0.2);
+
+        if ($socket === false) {
+            return false;
+        }
+
+        return fclose($socket);
+    };
+
+    while ($timeout > $interval) {
+        posix_kill(proc_get_status($process)['pid'], SIGINT);
+        posix_kill(proc_get_status($process)['pid'], SIGTERM);
+
+        usleep($interval);
+
+        if ($port_is_open()) {
+            $timeout -= $interval;
+        } else {
+            sleep(1);
+            assert_false(proc_get_status($process)['running'], 'Serve process is running!');
+            return;
+        }
+    }
+
+    throw new Exception('Timeout reached to close the port.');
+}
+
+function get(): array
+{
+    $url = "http://localhost:8000/";
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_HTTPGET, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Accept: text/html"));
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 1);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
+    $response = curl_exec($ch);
+    $error = curl_error($ch);
+    curl_close($ch);
+
+    return compact('response', 'error');
+}

--- a/Tests/System/VersionCommandTest.php
+++ b/Tests/System/VersionCommandTest.php
@@ -11,7 +11,7 @@ test(
     case: function () {
         $output = shell_exec('php ' . root() . 'phpkg -v');
 
-        assert_success('phpkg version 1.0.0', $output);
+        assert_success('phpkg version 1.1.0', $output);
     }
 );
 
@@ -20,6 +20,6 @@ test(
     case: function () {
         $output = shell_exec('php ' . root() . 'phpkg --version');
 
-        assert_success('phpkg version 1.0.0', $output);
+        assert_success('phpkg version 1.1.0', $output);
     }
 );

--- a/phpkg
+++ b/phpkg
@@ -14,6 +14,7 @@ require realpath(__DIR__ . '/Source/Commands/Man.php');
 require realpath(__DIR__ . '/Source/Commands/Migrate.php');
 require realpath(__DIR__ . '/Source/Commands/Remove.php');
 require realpath(__DIR__ . '/Source/Commands/Run.php');
+require realpath(__DIR__ . '/Source/Commands/Serve.php');
 require realpath(__DIR__ . '/Source/Commands/Update.php');
 require realpath(__DIR__ . '/Source/Commands/Version.php');
 require realpath(__DIR__ . '/Source/Commands/Watch.php');
@@ -52,6 +53,7 @@ match ($command) {
     'migrate' => \Phpkg\Commands\Migrate\run($environment),
     'remove' => \phpkg\Commands\Remove\run($environment),
     'run' => \phpkg\Commands\Run\run($environment),
+    'serve' => \phpkg\Commands\Serve\run($environment),
     'update' => \Phpkg\Commands\Update\run($environment),
     'version' => \Phpkg\Commands\Version\run(),
     'watch' => \Phpkg\Commands\Watch\run(),


### PR DESCRIPTION
This PR introduces a new feature to the phpkg application, allowing users to serve their applications without manually installing them on any machine. The new 'serve' command accepts a git URL to a phpkg application and serves it using the 'php -S' command. If no entry point is passed, the first entry point from the setting is used.

For instance, running the following command:

```shell
phpkg serve https://github.com/php-repos/daily-routine.git
```

will output:

```shell
Serving https://github.com/php-repos/daily-routine.git on http://localhost:8000
[Fri Mar 10 15:39:56 2023] PHP 8.2.3 Development Server (http://localhost:8000) start
```

Users can then access the application via their browser.

Note that the 'serve' command, similar to the 'run' command, uses the temp directory to download, install, and build the application. Therefore, any downloaded copy of the same version will not be downloaded again. However, please note that the application may be lost after restarting the server.
