### PR TITLE
Fix build for autoload composer files and files under bin directory

### DIFF
--- a/Tests/System/BuildCommand/BuildComposerProjectTest.php
+++ b/Tests/System/BuildCommand/BuildComposerProjectTest.php
@@ -21,12 +21,32 @@ test(
             file_exists(root() . '/TestRequirements/Fixtures/EmptyProject/builds/development/vendor/composer/package/file.php'),
             'Build for vendor directory failed.'
         );
+
+        assert_true(
+            file_exists(root() . '/TestRequirements/Fixtures/EmptyProject/builds/development/vendor/bin/file'),
+            'Build for vendor/bin directory failed.'
+        );
+
+        assert_true(
+            file_exists(root() . '/TestRequirements/Fixtures/EmptyProject/builds/development/vendor/autoload.php'),
+            'Build for autoload file failed.'
+        );
     },
     before: function () {
         shell_exec('php ' . root() . 'phpkg init --project=TestRequirements/Fixtures/EmptyProject --packages-directory=vendor');
         $project_directory = Path::from_string(root() . '/TestRequirements/Fixtures/EmptyProject');
+        // Simulate a package
         make_recursive($project_directory->append('vendor/composer/package'));
         $file = $project_directory->append('vendor/composer/package/file.php');
+        create($file, '');
+
+        // Simulate the bin directory
+        make_recursive($project_directory->append('vendor/bin'));
+        $file = $project_directory->append('vendor/bin/file');
+        create($file, '');
+
+        // Simulate the composer autoload file
+        $file = $project_directory->append('vendor/autoload.php');
         create($file, '');
     },
     after: function () {


### PR DESCRIPTION
When a project uses composer, there is a autoload file under the vendor directory. Also, some libraries add executables files under the vendor/bin directory. This PR add supports for building those files.
