### PR TITLE
Use a dedicated token for tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
           git submodule update
 
       - name: Set Credentials
-        run: php phpkg credential github.com ${{ secrets.GITHUB_TOKEN }}
+        run: php phpkg credential github.com ${{ secrets.PHPKG_GITHUB_TOKEN }}
 
       - name: Execute tests
         run: php test-runner


### PR DESCRIPTION
There is a rate limit on `GITHUB_TOKEN` default secret for the repository. This PR adds a new specific token for the phpkg repository.
