### PR TITLE
bugfix checking existance of a token

### DIFF
--- a/Source/Classes/Environment.php
+++ b/Source/Classes/Environment.php
@@ -10,5 +10,6 @@ class Environment
         public readonly Path $pwd,
         public readonly Path $credential_file,
         public readonly Path $temp,
+        public readonly ?string $github_token,
     ) {}
 }

--- a/Source/Environments.php
+++ b/Source/Environments.php
@@ -8,14 +8,26 @@ use Phpkg\Classes\Environment;
 use PhpRepos\FileManager\JsonFile;
 use const Phpkg\Git\GitHub\GITHUB_DOMAIN;
 
-function has_github_token(Environment $environment): bool
+function has_github_token_env(Environment $environment): bool
+{
+    return $environment->github_token !== null;
+}
+
+function has_defined_github_credential(Environment $environment): bool
 {
     return Credentials::from_array(JsonFile\to_array($environment->credential_file))
         ->has(fn (Credential $credential) => $credential->key === GITHUB_DOMAIN && strlen($credential->value) > 0);
 }
 
+function has_github_token(Environment $environment): bool
+{
+    return has_defined_github_credential($environment) || has_github_token_env($environment);
+}
+
 function github_token(Environment $environment): string
 {
-    return Credentials::from_array(JsonFile\to_array($environment->credential_file))
-        ->first(fn (Credential $credential) => $credential->key === GITHUB_DOMAIN)->value;
+    return has_defined_github_credential($environment)
+        ? Credentials::from_array(JsonFile\to_array($environment->credential_file))
+            ->first(fn (Credential $credential) => $credential->key === GITHUB_DOMAIN)->value
+        : $environment->github_token;
 }

--- a/Source/Environments.php
+++ b/Source/Environments.php
@@ -11,7 +11,7 @@ use const Phpkg\Git\GitHub\GITHUB_DOMAIN;
 function has_github_token(Environment $environment): bool
 {
     return Credentials::from_array(JsonFile\to_array($environment->credential_file))
-        ->has(fn (Credential $credential) => $credential->key === GITHUB_DOMAIN);
+        ->has(fn (Credential $credential) => $credential->key === GITHUB_DOMAIN && strlen($credential->value) > 0);
 }
 
 function github_token(Environment $environment): string

--- a/Source/Git/GitHub.php
+++ b/Source/Git/GitHub.php
@@ -141,7 +141,7 @@ function send(Request\Message $request): Conversation
 
     if (($status_code === Status::FORBIDDEN || $status_code === Status::TOO_MANY_REQUESTS) && $response_header->first(fn (Pair $header) => $header->key === 'x-ratelimit-remaining')->value == 0) {
         Request\Requests\has_authorization($request)
-            ? throw new RateLimitedException('You have reached the GitHub API rate limit. Please try again in ' . time() - $response_header->first(fn (Pair $header) => $header->key === 'x-ratelimit-reset')->value)
+            ? throw new RateLimitedException('You have reached the GitHub API rate limit. Please try again in ' . $response_header->first(fn (Pair $header) => $header->key === 'x-ratelimit-reset')->value - time() . ' seconds.')
             : throw new UnauthenticatedRateLimitedException('You have reached the GitHub API rate limit. Please add a token to your request and try again.');
     }
 

--- a/Source/System.php
+++ b/Source/System.php
@@ -17,9 +17,12 @@ function random_temp_directory(): string
 
 function environment(): Environment
 {
+    $github_token_var = getenv('GITHUB_TOKEN');
+
     return new Environment(
         Path::from_string($_SERVER['PWD']),
         Path::from_string($_SERVER['SCRIPT_FILENAME'])->sibling('credentials.json'),
         Path::from_string(sys_get_temp_dir())->append('phpkg'),
+        strlen($github_token_var) > 0 ? $github_token_var : null,
     );
 }

--- a/Tests/System/VersionCommandTest.php
+++ b/Tests/System/VersionCommandTest.php
@@ -14,7 +14,7 @@ test(
 
         $lines = explode("\n", trim($output));
         assert_true(1 === count($lines), 'Number of output lines do not match' . $output);
-        assert_success('phpkg version 1.7.0', $lines[0] . PHP_EOL);
+        assert_success('phpkg version 1.7.1', $lines[0] . PHP_EOL);
     }
 );
 
@@ -25,6 +25,6 @@ test(
 
         $lines = explode("\n", trim($output));
         assert_true(1 === count($lines), 'Number of output lines do not match' . $output);
-        assert_success('phpkg version 1.7.0', $lines[0] . PHP_EOL);
+        assert_success('phpkg version 1.7.1', $lines[0] . PHP_EOL);
     }
 );

--- a/phpkg
+++ b/phpkg
@@ -10,7 +10,7 @@ use PhpRepos\FileManager\Resolver;
 use function Phpkg\Exception\register_exception_handler;
 
 if (! empty(getopt('v::', ['version::']))) {
-    Output\success('phpkg version 1.7.0');
+    Output\success('phpkg version 1.7.1');
     exit(0);
 }
 


### PR DESCRIPTION
The default credential file shipping with phpkg has the github.com key but there is no value but the function was not checking the value itself. This PR checks the value and if there is empty string value, it goes without credentail. 