### PR TITLE
Support composer packages on run and serve

### DIFF
--- a/Import.php
+++ b/Import.php
@@ -54,6 +54,7 @@ spl_autoload_register(function ($class) {
         'PhpRepos\Console\Arguments' => realpath(__DIR__ . '/Packages/php-repos/console/Source/Arguments.php'),
         'PhpRepos\Console\Attributes\Argument' => realpath(__DIR__ . '/Packages/php-repos/console/Source/Attributes/Argument.php'),
         'PhpRepos\Console\Attributes\Description' => realpath(__DIR__ . '/Packages/php-repos/console/Source/Attributes/Description.php'),
+        'PhpRepos\Console\Attributes\ExcessiveArguments' => realpath(__DIR__ . '/Packages/php-repos/console/Source/Attributes/ExcessiveArguments.php'),
         'PhpRepos\Console\Attributes\LongOption' => realpath(__DIR__ . '/Packages/php-repos/console/Source/Attributes/LongOption.php'),
         'PhpRepos\Console\Attributes\ShortOption' => realpath(__DIR__ . '/Packages/php-repos/console/Source/Attributes/ShortOption.php'),
         'PhpRepos\Console\CommandParameter' => realpath(__DIR__ . '/Packages/php-repos/console/Source/CommandParameter.php'),

--- a/Source/Commands/Serve.php
+++ b/Source/Commands/Serve.php
@@ -9,6 +9,7 @@ use Phpkg\Git\Repository;
 use Phpkg\System;
 use PhpRepos\Console\Attributes\Argument;
 use PhpRepos\Console\Attributes\Description;
+use PhpRepos\Console\Attributes\ExcessiveArguments;
 use PhpRepos\FileManager\Directory;
 use PhpRepos\FileManager\File;
 use function Phpkg\Git\Repositories\download_archive;
@@ -29,6 +30,8 @@ return function (
     #[Argument]
     #[Description("The entry point you want to execute within the project. If not provided, it will use the first\navailable entry point.")]
     ?string $entry_point = null,
+    #[ExcessiveArguments]
+    array $entry_point_arguments = []
 ) {
     $environment = System\environment();
 
@@ -47,6 +50,16 @@ return function (
 
     if (! Directory\exists($root)) {
         Directory\make_recursive($root) && download_archive($repository, $root);
+
+        $project = new Project($root);
+        $composer_file = $project->root->append('composer.json');
+
+        // TODO: Find a composer package to be able to test this section, currently there is no test for this section.
+        if (! File\exists($project->config_file) && File\exists($composer_file)) {
+            PackageManager\migrate($project);
+            PackageManager\commit($project);
+        }
+
         $project = Project::initialized($root);
         PackageManager\install($project);
     }
@@ -66,7 +79,7 @@ return function (
 
     $command = 'php -S localhost:8000 -t ' . $entry_point_path->parent();
 
-    $process = proc_open($command, [STDIN, STDOUT, STDOUT], $pipes);
+    $process = proc_open($command . ' ' . implode(' ', $entry_point_arguments), [STDIN, STDOUT, STDOUT], $pipes);
 
     $terminate_server = function ($signal) use ($process) {
         $pid = proc_get_status($process)['pid'];

--- a/Tests/Application/MigratorTest.php
+++ b/Tests/Application/MigratorTest.php
@@ -624,7 +624,7 @@ test(
 
         $expected = [
             'packages' => [
-                'https://github.com/nikic/PHP-Parser.git' => 'v5.0.2',
+                'https://github.com/nikic/PHP-Parser.git' => 'v5.1.0',
             ],
             'import-file' => 'vendor/autoload.php'
         ];

--- a/Tests/System/RunCommand/RunCommandTest.php
+++ b/Tests/System/RunCommand/RunCommandTest.php
@@ -12,6 +12,7 @@ use function PhpRepos\FileManager\Resolver\root;
 use function PhpRepos\TestRunner\Assertions\Boolean\assert_false;
 use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
+use function Tests\Helper\reset_empty_project;
 
 test(
     title: 'it should run the given entry point on the given package',
@@ -64,5 +65,35 @@ test(
     after: function (Path $output) {
         delete($output);
         delete_recursive(Path::from_string(sys_get_temp_dir())->append('phpkg/runner/github.com/php-repos/chuck-norris'));
+    }
+);
+
+test(
+    title: 'it should run a composer package',
+    case: function (Path $path) {
+        $output = shell_exec('php ' . root() . 'phpkg run https://github.com/phpstan/phpstan.git phpstan analyze ' . $path->string() . ' -l 9');
+
+        assert_true(str_contains($output, '[ERROR] Found 2 errors'));
+    },
+    before: function () {
+        $path = Path::from_string(root() . 'TestRequirements/Fixtures/EmptyProject');
+        $content = <<<'EOD'
+<?php
+
+function a($b)
+{
+ echo $b;
+}
+
+a(1);
+
+EOD;
+
+        file_put_contents($path->append('index.php'), $content);
+
+        return $path;
+    },
+    after: function () {
+         reset_empty_project();
     }
 );

--- a/Tests/System/VersionCommandTest.php
+++ b/Tests/System/VersionCommandTest.php
@@ -14,7 +14,7 @@ test(
 
         $lines = explode("\n", trim($output));
         assert_true(1 === count($lines), 'Number of output lines do not match' . $output);
-        assert_success('phpkg version 1.7.2', $lines[0] . PHP_EOL);
+        assert_success('phpkg version 1.8.0', $lines[0] . PHP_EOL);
     }
 );
 
@@ -25,6 +25,6 @@ test(
 
         $lines = explode("\n", trim($output));
         assert_true(1 === count($lines), 'Number of output lines do not match' . $output);
-        assert_success('phpkg version 1.7.2', $lines[0] . PHP_EOL);
+        assert_success('phpkg version 1.8.0', $lines[0] . PHP_EOL);
     }
 );

--- a/phpkg
+++ b/phpkg
@@ -10,7 +10,7 @@ use PhpRepos\FileManager\Resolver;
 use function Phpkg\Exception\register_exception_handler;
 
 if (! empty(getopt('v::', ['version::']))) {
-    Output\success('phpkg version 1.7.2');
+    Output\success('phpkg version 1.8.0');
     exit(0);
 }
 


### PR DESCRIPTION
This PR adds the ability to use Composer packages with the run and serve commands. Additionally, it allows passing user arguments to the entry point when using run and serve.

For example, developers can now run phpstan on any project without defining it as a project dependency:

```bash
phpkg run https://github.com/phpstan/phpstan.git phpstan analyze  /path/to/project
```