### PR TITLE
Run and serve from local or using hash

### DIFF
--- a/Source/Commands/Serve.php
+++ b/Source/Commands/Serve.php
@@ -10,12 +10,14 @@ use Phpkg\System;
 use PhpRepos\Console\Attributes\Argument;
 use PhpRepos\Console\Attributes\Description;
 use PhpRepos\Console\Attributes\ExcessiveArguments;
+use PhpRepos\Console\Attributes\LongOption;
 use PhpRepos\FileManager\Directory;
 use PhpRepos\FileManager\File;
 use PhpRepos\FileManager\Path;
 use function Phpkg\Git\Repositories\download_archive;
 use function Phpkg\System\is_windows;
 use function PhpRepos\Cli\Output\line;
+use function PhpRepos\Datatype\Str\after_first_occurrence;
 
 /**
  * Serves an external project using PHP's built-in server on-the-fly.
@@ -33,6 +35,9 @@ return function (
     #[Argument]
     #[Description("The entry point you want to execute within the project. If not provided, it will use the first\navailable entry point.")]
     ?string $entry_point = null,
+    #[LongOption('version')]
+    #[Description("Specify the version of the project to serve.\nTo serve a specific version, use the `version` option. To serve a version based on a specific commit hash, use `development#{commit-hash}`.")]
+    ?string $version = null,
     #[ExcessiveArguments]
     array $entry_point_arguments = []
 ) {
@@ -47,27 +52,34 @@ return function (
 
     if (str_starts_with($url_or_path, 'https://') || str_starts_with($url_or_path, 'http://')) {
         $repository = Repository::from_url($url_or_path);
-        $repository->version = PackageManager\get_latest_version($repository);
-        $repository->hash = PackageManager\detect_hash($repository);
-        $root = $environment->temp->append('runner/github.com/' . $repository->owner . '/' . $repository->repo . '/' . $repository->hash);
-    } else {
-        $root = str_starts_with($url_or_path, '/') ? Path::from_string($url_or_path) : $environment->pwd->append($url_or_path);
-    }
 
-    if (! Directory\exists($root)) {
-        Directory\make_recursive($root) && download_archive($repository, $root);
-
-        $project = new Project($root);
-        $composer_file = $project->root->append('composer.json');
-
-        // TODO: Find a composer package to be able to test this section, currently there is no test for this section.
-        if (! File\exists($project->config_file) && File\exists($composer_file)) {
-            PackageManager\migrate($project);
-            PackageManager\commit($project);
+        if ($version && str_starts_with($version, PackageManager\DEVELOPMENT_VERSION . '#')) {
+            $repository->version = PackageManager\DEVELOPMENT_VERSION;
+            $repository->hash = after_first_occurrence($version, PackageManager\DEVELOPMENT_VERSION . '#');
+        } else {
+            $repository->version = $version && $version !== PackageManager\DEVELOPMENT_VERSION ? PackageManager\match_highest_version($repository, $version) : PackageManager\DEVELOPMENT_VERSION;
+            $repository->hash = PackageManager\detect_hash($repository);
         }
 
-        $project = Project::initialized($root);
-        PackageManager\install($project);
+        $root = $environment->temp->append('runner/github.com/' . $repository->owner . '/' . $repository->repo . '/' . $repository->hash);
+
+        if (! Directory\exists($root)) {
+            Directory\make_recursive($root) && download_archive($repository, $root);
+
+            $project = new Project($root);
+            $composer_file = $project->root->append('composer.json');
+
+            // TODO: Find a composer package to be able to test this section, currently there is no test for this section.
+            if (! File\exists($project->config_file) && File\exists($composer_file)) {
+                PackageManager\migrate($project);
+                PackageManager\commit($project);
+            }
+
+            $project = Project::initialized($root);
+            PackageManager\install($project);
+        }
+    } else {
+        $root = str_starts_with($url_or_path, '/') ? Path::from_string($url_or_path) : $environment->pwd->append($url_or_path);
     }
 
     $project = Project::initialized($root);

--- a/Tests/System/HelpCommandTest.php
+++ b/Tests/System/HelpCommandTest.php
@@ -21,7 +21,7 @@ Here you can see a list of available commands:
 \e[39m    install       Downloads and installs added packages into your project's directory.
 \e[39m    migrate       The `migrate` command is used to migrate from a Composer project to a `phpkg` project.
 \e[39m    remove        Removes the specified package from your project.
-\e[39m    run           Allows you to execute a project on-the-fly.
+\e[39m    run           Runs a project on-the-fly.
 \e[39m    serve         Serves an external project using PHP's built-in server on-the-fly.
 \e[39m    update        Allows you to update the version of a specified package in your PHP project.
 \e[39m    watch         Enables you to monitor file changes in your project and automatically build the project for each change.

--- a/Tests/System/RunCommand/RunCommandTest.php
+++ b/Tests/System/RunCommand/RunCommandTest.php
@@ -27,6 +27,42 @@ test(
 );
 
 test(
+    title: 'it should run the given version',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'phpkg run https://github.com/php-repos/dummy-tool.git --version=v1');
+
+        assert_true(str_contains($output, 'v1: Hello world from cli'));
+    },
+    after: function () {
+        delete_recursive(Path::from_string(sys_get_temp_dir())->append('phpkg/runner/github.com/php-repos/dummy-tool'));
+    }
+);
+
+test(
+    title: 'it should run the given version at the latest commit',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'phpkg run https://github.com/php-repos/dummy-tool.git --version=development');
+
+        assert_true(str_contains($output, 'Latest commit: Hello world from cli'));
+    },
+    after: function () {
+        delete_recursive(Path::from_string(sys_get_temp_dir())->append('phpkg/runner/github.com/php-repos/dummy-tool'));
+    }
+);
+
+test(
+    title: 'it should run the given version at the latest commit',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'phpkg run https://github.com/php-repos/dummy-tool.git --version=development#7a327643799d64632f2e1dbdb69f1f5eb6658881');
+
+        assert_true(str_contains($output, 'Specific commit: Hello world from cli'));
+    },
+    after: function () {
+        delete_recursive(Path::from_string(sys_get_temp_dir())->append('phpkg/runner/github.com/php-repos/dummy-tool'));
+    }
+);
+
+test(
     title: 'it should show error message when the entry point is not defined',
     case: function () {
         $output = shell_exec('php ' . root() . 'phpkg run https://github.com/php-repos/chuck-norris.git not-exists.php');

--- a/Tests/System/RunCommand/RunFromLocalTest.php
+++ b/Tests/System/RunCommand/RunFromLocalTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\System\RunCommand\RunFromLocalTest;
+
+use Phpkg\Classes\Project;
+use PhpRepos\FileManager\Filename;
+use PhpRepos\FileManager\Path;
+use function Phpkg\Application\PackageManager\commit;
+use function PhpRepos\FileManager\Resolver\root;
+use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Runner\test;
+use function Tests\Helper\reset_empty_project;
+
+test(
+    title: 'it should run a local package',
+    case: function (Project $project) {
+        $output = shell_exec('php ' . root() . 'phpkg run ' . $project->root);
+
+        assert_true($output === 'Hello from local cli');
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'phpkg init --project=TestRequirements/Fixtures/EmptyProject');
+
+        $project = Project::initialized(Path::from_string(root() . 'TestRequirements/Fixtures/EmptyProject'));
+        $project->config->entry_points->push(new Filename('index.php'));
+
+        $index_content = <<<EOD
+<?php
+
+echo 'Hello from local ' . php_sapi_name();
+
+EOD;
+        file_put_contents($project->root->append('index.php'), $index_content);
+
+        commit($project);
+
+        return $project;
+    },
+    after: function () {
+        reset_empty_project();
+    }
+);
+
+test(
+    title: 'it should run a local package using relative path',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'phpkg run TestRequirements/Fixtures/EmptyProject');
+
+        assert_true($output === 'Hello from local cli');
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'phpkg init --project=TestRequirements/Fixtures/EmptyProject');
+
+        $project = Project::initialized(Path::from_string(root() . 'TestRequirements/Fixtures/EmptyProject'));
+        $project->config->entry_points->push(new Filename('index.php'));
+
+        $index_content = <<<EOD
+<?php
+
+echo 'Hello from local ' . php_sapi_name();
+
+EOD;
+        file_put_contents($project->root->append('index.php'), $index_content);
+
+        commit($project);
+
+        return $project;
+    },
+    after: function () {
+        reset_empty_project();
+    }
+);

--- a/Tests/System/VersionCommandTest.php
+++ b/Tests/System/VersionCommandTest.php
@@ -14,7 +14,7 @@ test(
 
         $lines = explode("\n", trim($output));
         assert_true(1 === count($lines), 'Number of output lines do not match' . $output);
-        assert_success('phpkg version 1.8.1', $lines[0] . PHP_EOL);
+        assert_success('phpkg version 1.9.0', $lines[0] . PHP_EOL);
     }
 );
 
@@ -25,6 +25,6 @@ test(
 
         $lines = explode("\n", trim($output));
         assert_true(1 === count($lines), 'Number of output lines do not match' . $output);
-        assert_success('phpkg version 1.8.1', $lines[0] . PHP_EOL);
+        assert_success('phpkg version 1.9.0', $lines[0] . PHP_EOL);
     }
 );

--- a/phpkg
+++ b/phpkg
@@ -10,7 +10,7 @@ use PhpRepos\FileManager\Resolver;
 use function Phpkg\Exception\register_exception_handler;
 
 if (! empty(getopt('v::', ['version::']))) {
-    Output\success('phpkg version 1.8.1');
+    Output\success('phpkg version 1.9.0');
     exit(0);
 }
 


### PR DESCRIPTION
This PR enhances the `phpkg` tool by adding support for using the `run` and `serve` commands with local packages and specific commit hashes. 
Examples of the updated usage are as follows:
```
# Running a package from an absolute path
phpkg run /absolute/path/to/package

# Running a package from a relative path
phpkg run ../relative/path/to/package

# Running a package from a Git repository with a specific commit hash
phpkg run https://github.com/owner/repo.git --version=development#commit-hash
```