### PR TITLE
use current version to build phpkg

### DIFF
--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -19,8 +19,10 @@ jobs:
       - name: Build project
         run: |
           phpkg install
-          phpkg build production
-      - name: Remove unneccessary files
+          phpkg build
+          cd builds/development
+          ./phpkg build production --project=../../
+      - name: Remove unnecessary files
         run: |
           cd builds/production
           rm -fR .github


### PR DESCRIPTION
The live version of phpkg can not build the current code. This PR uses self version to make production build.