### PR TITLE
Fix convertor bug to not remove the last character when it is not '/'

### DIFF
--- a/Source/Application/Migrator.php
+++ b/Source/Application/Migrator.php
@@ -12,6 +12,7 @@ use function Phpkg\Git\Version\compare;
 use function Phpkg\Git\Version\has_major_change;
 use function Phpkg\Git\Version\is_stable;
 use function Phpkg\Packagist\git_url;
+use function PhpRepos\Datatype\Str\last_character;
 use function PhpRepos\Datatype\Str\remove_last_character;
 
 function is_dev_package(string $version_pattern): bool
@@ -55,7 +56,10 @@ function composer(array $composer_config): array
                 continue;
             }
 
-            $config['map'][remove_last_character($namespace)] = remove_last_character($path);
+            $namespace = last_character($namespace) === '\\' ? remove_last_character($namespace) : $namespace;
+            $path = last_character($path) === '/' ? remove_last_character($path) : $path;
+
+            $config['map'][$namespace] = $path;
         }
     }
 

--- a/Tests/Application/MigratorTest.php
+++ b/Tests/Application/MigratorTest.php
@@ -51,6 +51,29 @@ test(
         $composer_config = [
             'autoload' => [
                 'psr-4' => [
+                    "PhpParser\\" => "lib/PhpParser",
+                ]
+            ]
+        ];
+        $result = composer($composer_config);
+
+        $expected = [
+            'map' => [
+                'PhpParser' => 'lib/PhpParser',
+            ],
+            'import-file' => 'vendor/autoload.php',
+        ];
+
+        assert_true($expected === $result, 'Map has not been detected properly!');
+    }
+);
+
+test(
+    title: 'it should ignore when an array defined in any psr-4',
+    case: function () {
+        $composer_config = [
+            'autoload' => [
+                'psr-4' => [
                     "App\\" => ["src/", "app/"],
                 ]
             ]
@@ -239,7 +262,7 @@ test(
 
         $expected = [
             'packages' => [
-                'https://github.com/myclabs/DeepCopy.git' => '1.12.1',
+                'https://github.com/myclabs/DeepCopy.git' => '1.13.0',
             ],
             'import-file' => 'vendor/autoload.php'
         ];
@@ -295,7 +318,7 @@ test(
         $expected = [
             'packages' => [
                 'https://github.com/symfony/thanks.git' => 'v1.4.0',
-                'https://github.com/myclabs/DeepCopy.git' => '1.12.1',
+                'https://github.com/myclabs/DeepCopy.git' => '1.13.0',
             ],
             'import-file' => 'vendor/autoload.php'
         ];
@@ -597,7 +620,7 @@ test(
 
         $expected = [
             'packages' => [
-                'https://github.com/doctrine/common.git' => '3.4.5',
+                'https://github.com/doctrine/common.git' => '3.5.0',
             ],
             'import-file' => 'vendor/autoload.php'
         ];
@@ -624,7 +647,7 @@ test(
 
         $expected = [
             'packages' => [
-                'https://github.com/nikic/PHP-Parser.git' => 'v5.3.1',
+                'https://github.com/nikic/PHP-Parser.git' => 'v5.4.0',
             ],
             'import-file' => 'vendor/autoload.php'
         ];

--- a/Tests/System/VersionCommandTest.php
+++ b/Tests/System/VersionCommandTest.php
@@ -14,7 +14,7 @@ test(
 
         $lines = explode("\n", trim($output));
         assert_true(1 === count($lines), 'Number of output lines do not match' . $output);
-        assert_success('phpkg version 1.11.0', $lines[0] . PHP_EOL);
+        assert_success('phpkg version 2.1.0', $lines[0] . PHP_EOL);
     }
 );
 
@@ -25,6 +25,6 @@ test(
 
         $lines = explode("\n", trim($output));
         assert_true(1 === count($lines), 'Number of output lines do not match' . $output);
-        assert_success('phpkg version 1.11.0', $lines[0] . PHP_EOL);
+        assert_success('phpkg version 2.1.0', $lines[0] . PHP_EOL);
     }
 );

--- a/phpkg
+++ b/phpkg
@@ -8,7 +8,7 @@ use PhpRepos\FileManager\Resolver;
 use function Phpkg\Exception\Handler\register_exception_handler;
 
 if (! empty(getopt('v::', ['version::']))) {
-    Output\success('phpkg version 1.11.0');
+    Output\success('phpkg version 2.1.0');
     exit(0);
 }
 


### PR DESCRIPTION
- Fix tests to match the latest versions of packages
- Fix the migrator function to not remove the last character when there is no trailing /